### PR TITLE
Updated ring versions from 1.1.8 to 1.4.0

### DIFF
--- a/clj/project.clj
+++ b/clj/project.clj
@@ -1,5 +1,5 @@
 (defproject clojure-example "0.1.0-SNAPSHOT"
   :dependencies [[org.clojure/clojure "1.6.0"]
-  				 [ring/ring-core "1.1.8"]
-  				 [ring/ring-jetty-adapter "1.1.8"]]
+  				 [ring/ring-core "1.4.0"]
+  				 [ring/ring-jetty-adapter "1.4.0"]]
   :dev_dependencies [[lein-ring "0.4.5"]])


### PR DESCRIPTION
This will update the ring libraries to their most current versions: 1.4.0