### PR TITLE
Bump node to recent LTS

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -2,7 +2,7 @@
   "name": "node-example",
   "version": "0.0.1",
   "engines": {
-    "node": "0.10.x",
-    "npm": "2.x"
+    "node": "6.x",
+    "npm": "3.x"
   }
 }


### PR DESCRIPTION
```
-----> Installing binaries
       engines.node (package.json):  0.10.x
       engines.npm (package.json):   2.x
       Downloading and installing node ...
DEPENDENCY MISSING IN MANIFEST:
Unfortunately, we are either unable to resolve the dependency into
a binary and version number or the requested version or version range is not supported.
Please replace the URL with a valid link or the requested version/range
with a supported version or version range.
-----> Build failed
       We're sorry this build is failing! You find more info about the nodejs buildpack here:
       https://docs.cloudfoundry.org/buildpacks/node/index.html
Staging failed: Buildpack compilation step failed

FAILED
BuildpackCompileFailed
```

Looks like the node buildpack doesn't support node `0.10` anymore, let's update it!
