### PR TITLE
Move `--random-route` flag to docs.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ All of these examples, except Java, have the same usage. For Java, see its [INST
 1. `cd` into the subdirectory for whatever language/framework you feel most comfortable with.
 1. Deploy the application with `cf push`. Look for `urls` value when the push completes.
     ```bash{9}
-    cf push 
+    cf push --random-route
     ...
     Creating app APP in org / space
     OK

--- a/clojure/manifest.yml
+++ b/clojure/manifest.yml
@@ -2,5 +2,4 @@
 applications:
 - name: clojure
   buildpack: git://github.com/heroku/heroku-buildpack-clojure.git
-  random-route: true
   memory: 256M

--- a/dotnet-core/manifest.yml
+++ b/dotnet-core/manifest.yml
@@ -2,7 +2,6 @@
 applications:
 - name: dotnet-core
   buildpack: dotnet_core_buildpack
-  random-route: true
   memory: 256M
   env:
     CACHE_NUGET_PACKAGES: false

--- a/java-see/manifest.yml
+++ b/java-see/manifest.yml
@@ -2,6 +2,5 @@
 applications:
 - name: java
   memory: 768M
-  random-route: true
   path: build/distributions/java-hello-world-cf-example.zip
   buildpack: java_buildpack

--- a/nodejs/manifest.yml
+++ b/nodejs/manifest.yml
@@ -3,4 +3,3 @@ buildpack: nodejs_buildpack
 applications:
 - name: nodejs-example
   memory: 256M
-  random-route: true

--- a/php/manifest.yml
+++ b/php/manifest.yml
@@ -3,4 +3,3 @@ applications:
 - name: php
   memory: 256M
   buildpack: php_buildpack
-  random-route: true

--- a/python-flask/manifest.yml
+++ b/python-flask/manifest.yml
@@ -3,4 +3,3 @@ buildpack: python_buildpack
 applications:
 - name: flask-example
   memory: 256M
-  random-route: true

--- a/ruby-padrino/manifest.yml
+++ b/ruby-padrino/manifest.yml
@@ -3,4 +3,3 @@ applications:
 - name: ruby-padrino-example
   command: bundle exec unicorn -p $PORT -c ./config/unicorn.rb 
   memory: 256M
-  random-route: true

--- a/ruby-sinatra/manifest.yml
+++ b/ruby-sinatra/manifest.yml
@@ -3,4 +3,3 @@ applications:
 - name: ruby-sinatra
   buildpack: ruby_buildpack
   memory: 256M
-  random-route: true


### PR DESCRIPTION
So that cloud.gov can deploy sample applications with stable urls for
canary testing.