### PR TITLE
Move buildpack config into applications.

### DIFF
--- a/nodejs/manifest.yml
+++ b/nodejs/manifest.yml
@@ -1,5 +1,5 @@
 ---
-buildpack: nodejs_buildpack
 applications:
 - name: nodejs-example
+  buildpack: nodejs_buildpack
   memory: 256M

--- a/python-flask/manifest.yml
+++ b/python-flask/manifest.yml
@@ -1,5 +1,5 @@
 ---
-buildpack: python_buildpack
 applications:
 - name: flask-example
+  buildpack: python_buildpack
   memory: 256M


### PR DESCRIPTION
Top-level buildpack configuration is now deprecated.