### PR TITLE
Pluralize buildpacks in manifests.

### DIFF
--- a/clojure/manifest.yml
+++ b/clojure/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
 - name: clojure
-  buildpack: git://github.com/heroku/heroku-buildpack-clojure.git
+  buildpacks:
+    - git://github.com/heroku/heroku-buildpack-clojure.git
   memory: 256M

--- a/dotnet-core/manifest.yml
+++ b/dotnet-core/manifest.yml
@@ -1,7 +1,8 @@
 ---
 applications:
 - name: dotnet-core
-  buildpack: dotnet_core_buildpack
+  buildpacks:
+    - dotnet_core_buildpack
   memory: 256M
   env:
     CACHE_NUGET_PACKAGES: false

--- a/java-see/manifest.yml
+++ b/java-see/manifest.yml
@@ -3,4 +3,5 @@ applications:
 - name: java
   memory: 768M
   path: build/distributions/java-hello-world-cf-example.zip
-  buildpack: java_buildpack
+  buildpacks:
+    - java_buildpack

--- a/nodejs/manifest.yml
+++ b/nodejs/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
 - name: nodejs-example
-  buildpack: nodejs_buildpack
+  buildpacks:
+    - nodejs_buildpack
   memory: 256M

--- a/php/manifest.yml
+++ b/php/manifest.yml
@@ -2,4 +2,5 @@
 applications:
 - name: php
   memory: 256M
-  buildpack: php_buildpack
+  buildpacks:
+    - php_buildpack

--- a/python-flask/manifest.yml
+++ b/python-flask/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
 - name: flask-example
-  buildpack: python_buildpack
+  buildpacks:
+    - python_buildpack
   memory: 256M

--- a/ruby-sinatra/manifest.yml
+++ b/ruby-sinatra/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
 - name: ruby-sinatra
-  buildpack: ruby_buildpack
+  buildpacks:
+    - ruby_buildpack
   memory: 256M


### PR DESCRIPTION
As per the deprecation notice I just received when deploying one of these sample apps, `buildpack` (singular) was deprecated in favor of `buildpacks` (plural, array). 

This PR blanket updates them through the sample projects, though I have only run the `nodejs` example. I feel pretty safe making the other changes without manually testing them, but let me know if you disagree and I can :fidget-spinner: up all the examples to double-check. 