### PR TITLE
Add go application name to manifest

### DIFF
--- a/go-hello/manifest.yml
+++ b/go-hello/manifest.yml
@@ -1,3 +1,5 @@
 ---
+applications:
+- name: go-hello
   env:
     GOPACKAGENAME: go-hello


### PR DESCRIPTION
Add application name to manifest because `cf push` produces error
```
go-hello:master λ cf push
Pushing from manifest to org system / space qaspace as admin...
Using manifest file /home/kravciak/git/cf-hello-worlds/go-hello/manifest.yml

Deprecation warning: Specifying app manifest attributes at the top level is deprecated. Found: env.
Please see http://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#deprecated for alternatives and other app manifest deprecations. This feature will be removed in the future.

Using manifest file /home/kravciak/git/cf-hello-worlds/go-hello/manifest.yml

FAILED
Error: App name is a required field
```

- Deprecated top level attributes:
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#yaml-anchors

- Minimal manifest requires app name:
https://docs.cloudfoundry.org/devguide/deploy-apps/manifest.html#minimal-manifest