### PR TITLE
Turn on CF_TRACE for these deployments

### DIFF
--- a/pipeline.yml
+++ b/pipeline.yml
@@ -201,6 +201,7 @@ resources:
     password: ((cf-password))
     organization: ((cf-organization))
     space: ((cf-space))
+    verbose: true
 
 - name: deploy-ruby-padrino
   type: cf


### PR DESCRIPTION
Since this is an automated test that we generally only pay attention to
when there is something wrong with the platform, we should have CF_TRACE
set to true all the time in case things break. Sure it's noisy, but that
noise is helpful when we're debugging and troubleshooting issues
customer's may be experiencing.