### PR TITLE
Buildpack deprecation warning & random routes

### DIFF
--- a/clojure/manifest.yml
+++ b/clojure/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: clojure
+  random-route: true
   buildpacks:
     - git://github.com/heroku/heroku-buildpack-clojure.git
   memory: 256M

--- a/clojure/manifest.yml
+++ b/clojure/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
 - name: clojure
-  buildpack: git://github.com/heroku/heroku-buildpack-clojure.git
+  buildpacks:
+    - git://github.com/heroku/heroku-buildpack-clojure.git
   memory: 256M

--- a/dotnet-core/manifest.yml
+++ b/dotnet-core/manifest.yml
@@ -1,7 +1,8 @@
 ---
 applications:
 - name: dotnet-core
-  buildpack: dotnet_core_buildpack
+  buildpacks:
+    - dotnet_core_buildpack
   memory: 256M
   env:
     CACHE_NUGET_PACKAGES: false

--- a/dotnet-core/manifest.yml
+++ b/dotnet-core/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: dotnet-core
+  random-route: true
   buildpacks:
     - dotnet_core_buildpack
   memory: 256M

--- a/go-hello/manifest.yml
+++ b/go-hello/manifest.yml
@@ -1,3 +1,4 @@
 ---
+  random-route: true
   env:
     GOPACKAGENAME: go-hello

--- a/java-see/manifest.yml
+++ b/java-see/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: java
+  random-route: true
   memory: 768M
   path: build/distributions/java-hello-world-cf-example.zip
   buildpacks:

--- a/java-see/manifest.yml
+++ b/java-see/manifest.yml
@@ -3,4 +3,5 @@ applications:
 - name: java
   memory: 768M
   path: build/distributions/java-hello-world-cf-example.zip
-  buildpack: java_buildpack
+  buildpacks:
+    - java_buildpack

--- a/nodejs/manifest.yml
+++ b/nodejs/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: nodejs-example
+  random-route: true
   buildpacks:
     - nodejs_buildpack
   memory: 256M

--- a/nodejs/manifest.yml
+++ b/nodejs/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
 - name: nodejs-example
-  buildpack: nodejs_buildpack
+  buildpacks:
+    - nodejs_buildpack
   memory: 256M

--- a/php/manifest.yml
+++ b/php/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: php
+  random-route: true
   memory: 256M
   buildpacks:
     - php_buildpack

--- a/php/manifest.yml
+++ b/php/manifest.yml
@@ -2,4 +2,5 @@
 applications:
 - name: php
   memory: 256M
-  buildpack: php_buildpack
+  buildpacks:
+    - php_buildpack

--- a/python-flask/manifest.yml
+++ b/python-flask/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: flask-example
+  random-route: true
   buildpacks:
     - python_buildpack
   memory: 256M

--- a/python-flask/manifest.yml
+++ b/python-flask/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
 - name: flask-example
-  buildpack: python_buildpack
+  buildpacks:
+    - python_buildpack
   memory: 256M

--- a/ruby-padrino/manifest.yml
+++ b/ruby-padrino/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
 - name: ruby-padrino-example
+  random-route: true
   command: bundle exec unicorn -p $PORT -c ./config/unicorn.rb 
   memory: 256M

--- a/ruby-sinatra/manifest.yml
+++ b/ruby-sinatra/manifest.yml
@@ -1,6 +1,7 @@
 ---
 applications:
 - name: ruby-sinatra
+  random-route: true
   buildpacks:
     - ruby_buildpack
   memory: 256M

--- a/ruby-sinatra/manifest.yml
+++ b/ruby-sinatra/manifest.yml
@@ -1,5 +1,6 @@
 ---
 applications:
 - name: ruby-sinatra
-  buildpack: ruby_buildpack
+  buildpacks:
+    - ruby_buildpack
   memory: 256M


### PR DESCRIPTION
This PR has two changes: 
first, `buildpack` is deprecated in favor of `buildpacks`, so this avoids using `buildpack`
second, this adds `random-routes`, so users' routes are less likely to collide with each other.