### PR TITLE
Avoids call to autopilot plugin

### DIFF
--- a/dotnet-core/manifest.yml
+++ b/dotnet-core/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: dotnet-core
+- name: test-dotnet-core
   random-route: true
   buildpacks:
     - dotnet_core_buildpack

--- a/java-see/manifest.yml
+++ b/java-see/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: java
+- name: test-java
   random-route: true
   memory: 768M
   path: build/distributions/java-hello-world-cf-example.zip

--- a/nodejs/manifest.yml
+++ b/nodejs/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: nodejs-example
+- name: test-nodejs
   random-route: true
   buildpacks:
     - nodejs_buildpack

--- a/php/manifest.yml
+++ b/php/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: php
+- name: test-php
   random-route: true
   memory: 256M
   buildpacks:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -10,7 +10,6 @@ jobs:
     params:
       path: cf-hello-worlds/python-flask
       manifest: cf-hello-worlds/python-flask/manifest.yml
-      current_app_name: test-python-flask
   on_failure:
     put: slack
     params: &slack-params
@@ -37,7 +36,6 @@ jobs:
     params:
       path: cf-hello-worlds/ruby-padrino
       manifest: cf-hello-worlds/ruby-padrino/manifest.yml
-      current_app_name: test-ruby-padrino
   on_failure:
     put: slack
     params:
@@ -62,7 +60,6 @@ jobs:
     params:
       path: cf-hello-worlds/ruby-sinatra
       manifest: cf-hello-worlds/ruby-sinatra/manifest.yml
-      current_app_name: test-ruby-sinatra
   on_failure:
     put: slack
     params:
@@ -87,7 +84,6 @@ jobs:
     params:
       path: cf-hello-worlds/nodejs
       manifest: cf-hello-worlds/nodejs/manifest.yml
-      current_app_name: test-nodejs
   on_failure:
     put: slack
     params:
@@ -112,7 +108,6 @@ jobs:
     params:
       path: cf-hello-worlds/php
       manifest: cf-hello-worlds/php/manifest.yml
-      current_app_name: test-php
   on_failure:
     put: slack
     params:
@@ -163,7 +158,6 @@ jobs:
     params:
       path: cf-hello-worlds/dotnet-core
       manifest: cf-hello-worlds/dotnet-core/manifest.yml
-      current_app_name: test-dotnet-core
   on_failure:
     put: slack
     params:

--- a/pipeline.yml
+++ b/pipeline.yml
@@ -139,7 +139,6 @@ jobs:
     params:
       path: cf-hello-worlds-build/java-see
       manifest: cf-hello-worlds-build/java-see/manifest.yml
-      current_app_name: test-java
   on_failure:
     put: slack
     params:

--- a/python-flask/manifest.yml
+++ b/python-flask/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: flask-example
+- name: test-python-flask
   random-route: true
   buildpacks:
     - python_buildpack

--- a/ruby-padrino/manifest.yml
+++ b/ruby-padrino/manifest.yml
@@ -1,6 +1,5 @@
 ---
 applications:
 - name: test-ruby-padrino
-  random-route: false
   command: bundle exec unicorn -p $PORT -c ./config/unicorn.rb 
   memory: 256M

--- a/ruby-padrino/manifest.yml
+++ b/ruby-padrino/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: ruby-padrino-example
-  random-route: true
+- name: test-ruby-padrino
+  random-route: false
   command: bundle exec unicorn -p $PORT -c ./config/unicorn.rb 
   memory: 256M

--- a/ruby-sinatra/manifest.yml
+++ b/ruby-sinatra/manifest.yml
@@ -1,6 +1,6 @@
 ---
 applications:
-- name: ruby-sinatra
+- name: test-ruby-sinatra
   random-route: true
   buildpacks:
     - ruby_buildpack


### PR DESCRIPTION
The Concourse CF resource switches on the `current_app_name` parameter to then call the autopilot zero-downtime-deploy plugin, which in turn uses an old version of the CF CLI binary.  This avoids that and removes our dependency on the plugin.  In the future may want to remove dependency on CF resource altogether unless we can convince Pivotal to maintain it.  