### PR TITLE
Update node and dotnet versions

### DIFF
--- a/dotnet-core/dotnet-core-hello-world.csproj
+++ b/dotnet-core/dotnet-core-hello-world.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.0</TargetFramework>
+    <TargetFramework>netcoreapp2.1</TargetFramework>
     <DebugType>portable</DebugType>
     <AssemblyName>dotnet-core-hello-world</AssemblyName>
     <OutputType>Exe</OutputType>
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.0.*" />
-    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.0.*" />
-    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.0.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.IISIntegration" Version="2.1.*" />
+    <PackageReference Include="Microsoft.AspNetCore.Server.Kestrel" Version="2.1.*" />
+    <PackageReference Include="Microsoft.Extensions.Configuration.CommandLine" Version="2.1.*" />
   </ItemGroup>
 </Project>

--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -2,7 +2,7 @@
   "name": "node-example",
   "version": "0.0.1",
   "engines": {
-    "node": "6.x",
+    "node": "8.x",
     "npm": "3.x"
   }
 }


### PR DESCRIPTION
cf 9.2 removes buildpacks that supported the old versions.