### PR TITLE
bump node version to one supported by this buildpack

### DIFF
--- a/nodejs/package.json
+++ b/nodejs/package.json
@@ -2,7 +2,7 @@
   "name": "node-example",
   "version": "0.0.1",
   "engines": {
-    "node": "8.x",
-    "npm": "3.x"
+    "node": "10.x",
+    "npm": "6.x"
   }
 }


### PR DESCRIPTION
node 8 does not work with our buildpacks. This bumps us to node 10. I tested this in my sandbox, and it seems to work.

# Security Considerations
None