### PR TITLE
use correct framework

### DIFF
--- a/dotnet-core/dotnet-core-hello-world.csproj
+++ b/dotnet-core/dotnet-core-hello-world.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp8.0</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <RootNamespace>dot_net_gov</RootNamespace>
   </PropertyGroup>
 


### PR DESCRIPTION
the undocumented names (without period in dotnet 5+) can drop their support when move to double-digit (to avoid potential conflicts) https://learn.microsoft.com/en-us/dotnet/standard/frameworks#supported-target-frameworks

## Changes proposed in this pull request:
-
-
-

## security considerations
[Note the any security considerations here, or make note of why there are none]
