### PR TITLE
Pin java buildpack back to system

### DIFF
--- a/java-hello/manifest.yml
+++ b/java-hello/manifest.yml
@@ -2,7 +2,7 @@
 applications:
 - name: test-java-hello
   buildpacks:
-  - https://github.com/cloudfoundry/java-buildpack.git#feature/go-migration
+  - java_buildpack
   random-route: true
   memory: 768M
   path: target/hello-world-0.0.1-SNAPSHOT.jar


### PR DESCRIPTION
## Changes proposed in this pull request:
- Reverts-ish https://github.com/cloud-gov/cf-hello-worlds/pull/200, leaves a placeholder to set the buildpacks array but pointing it back to the system buildpack
- Part of https://github.com/cloud-gov/product/issues/2836
-

## security considerations
None, tests buildpacks
